### PR TITLE
ENDES/ENAHO códigos añadidos 2020-2024

### DIFF
--- a/R/archivos_enaho.R
+++ b/R/archivos_enaho.R
@@ -19,8 +19,13 @@ archivos_enaho <- function(periodo, codigo_modulo) {
   temp <- tempfile() ; tempdir <- tempdir()
   
   # Genera una matriz con el número identificador de versiones por cada año
-  versiones <- matrix(c(2019, 687, 
-                        2018, 634, 
+  versiones <- matrix(c(2024,966,# periodo anual
+                        2023,906,
+                        2022,784,
+                        2021,759,
+                        2020,737,
+                        2019,687, 
+                        2018,634, 
                         2017,603,
                         2016,546,
                         2015,498,
@@ -29,7 +34,7 @@ archivos_enaho <- function(periodo, codigo_modulo) {
                         2012,324,
                         2011,291,
                         2010,279,
-                        2009,258,
+                        2009,285,
                         2008,284,
                         2007,283,
                         2006,282,

--- a/R/archivos_endes.R
+++ b/R/archivos_endes.R
@@ -19,11 +19,29 @@ archivos_endes <- function(periodo, codigo_modulo) {
   temp <- tempfile() ; tempdir <- tempdir()
   
   # Genera una matriz con el número identificador de versiones por cada año
-  versiones <- matrix(c(2019, 691, 
-                        2018, 638, 2017,605,2016,548,2015,504,2014,441,
-                        2013,407,2012,323,2011,290,2010,260,
-                        2009,238,2008,209,2007,194,2006,183,
-                        2005,150,2004,120),byrow = T,ncol = 2)
+  versiones <- matrix(c(2024,968,
+                        2023,910,
+                        2022,786,
+                        2021,760,
+                        2020,739,
+                        2019, 691,
+                        2018, 638,
+                        2017,605,
+                        2016,548,
+                        2015,504,
+                        2014,441,
+                        2013,407,
+                        2012,323,
+                        2011,290,
+                        2010,260,
+                        2009,238,
+                        2008,209,
+                        2007,194,
+                        2006,183,
+                        2005,150,
+                        2004,120),
+                        byrow = T,
+                        ncol = 2)
   
   # Extrae el código de la encuesta con la matriz versiones
   codigo_encuesta <- versiones[versiones[,1] == periodo,2]

--- a/R/consulta_enaho.R
+++ b/R/consulta_enaho.R
@@ -20,8 +20,13 @@ consulta_enaho <- function(periodo, codigo_modulo, base, guardar = FALSE, ruta =
   temp <- tempfile() ; tempdir <- tempdir()
   
   # Genera una matriz con el número identificador de versiones por cada año
-  versiones <- matrix(c(2019, 687, 
-                        2018, 634, 
+  versiones <- matrix(c(2024,966,# periodo anual
+                        2023,906,
+                        2022,784,
+                        2021,759,
+                        2020,737,
+                        2019,687, 
+                        2018,634, 
                         2017,603,
                         2016,546,
                         2015,498,
@@ -30,7 +35,7 @@ consulta_enaho <- function(periodo, codigo_modulo, base, guardar = FALSE, ruta =
                         2012,324,
                         2011,291,
                         2010,279,
-                        2009,258,
+                        2009,285,#actualizado, codigo de encuesta es 285 para año 2009
                         2008,284,
                         2007,283,
                         2006,282,

--- a/R/consulta_endes.R
+++ b/R/consulta_endes.R
@@ -21,11 +21,29 @@ consulta_endes <- function(periodo, codigo_modulo, base, guardar = FALSE, ruta =
   temp <- tempfile() ; tempdir <- tempdir()
   
   # Genera una matriz con el número identificador de versiones por cada año
-  versiones <- matrix(c(2019, 691, 
-                        2018, 638, 2017,605,2016,548,2015,504,2014,441,
-                        2013,407,2012,323,2011,290,2010,260,
-                        2009,238,2008,209,2007,194,2006,183,
-                        2005,150,2004,120),byrow = T,ncol = 2)
+  versiones <- matrix(c(2024,968,
+                        2023,910,
+                        2022,786,
+                        2021,760,
+                        2020,739,
+                        2019,691, 
+                        2018,638, 
+                        2017,605,
+                        2016,548,
+                        2015,504,
+                        2014,441,
+                        2013,407,
+                        2012,323,
+                        2011,290,
+                        2010,260,
+                        2009,238,
+                        2008,209,
+                        2007,194,
+                        2006,183,
+                        2005,150,
+                        2004,120),
+                        byrow = T,
+                        ncol = 2)
   
   # Extrae el código de la encuesta con la matriz versiones
   codigo_encuesta <- versiones[versiones[,1] == periodo,2]


### PR DESCRIPTION
Se añadieron los códigos de las encuestas de los años 2020-2024 para las encuestas ENDES/ENAHO.
Para ENAHO, se emplearon los códigos anuales de las condiciones de vida y pobreza - ENAHO metodología actualizada. 

![enaho](https://github.com/user-attachments/assets/00c10d92-2915-46fc-9cc5-be4c152b6925)
